### PR TITLE
feat: add page customization controls

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,138 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Hello World</title>
+  <style>
+    body {
+      margin: 0;
+      font-family: 'Comic Sans MS', cursive, sans-serif;
+    }
+
+    body.gradient {
+      background: linear-gradient(-45deg, #ff9a9e, #fad0c4, #fad0c4, #ff9a9e);
+      background-size: 400% 400%;
+      animation: gradientBG 15s ease infinite;
+    }
+
+    @keyframes gradientBG {
+      0% {background-position: 0% 50%;}
+      50% {background-position: 100% 50%;}
+      100% {background-position: 0% 50%;}
+    }
+
+    .hero {
+      min-height: 100vh;
+      display: flex;
+      justify-content: center;
+      align-items: center;
+    }
+
+    #title {
+      font-size: 5em;
+      color: #fff;
+      text-shadow: 0 0 10px rgba(0,0,0,0.4);
+    }
+
+    #title.float { animation: float 3s ease-in-out infinite; }
+    #title.spin { animation: spin 3s linear infinite; }
+    #title.pulse { animation: pulse 1.5s ease-in-out infinite; }
+
+    @keyframes float {
+      0% { transform: translateY(0); }
+      50% { transform: translateY(-20px); }
+      100% { transform: translateY(0); }
+    }
+
+    @keyframes spin {
+      from { transform: rotate(0deg); }
+      to { transform: rotate(360deg); }
+    }
+
+    @keyframes pulse {
+      0% { transform: scale(1); }
+      50% { transform: scale(1.1); }
+      100% { transform: scale(1); }
+    }
+
+    .controls {
+      padding: 20px;
+      display: flex;
+      flex-wrap: wrap;
+      gap: 10px;
+      justify-content: center;
+      font-size: 0.9rem;
+    }
+
+    .controls label {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      gap: 4px;
+    }
+  </style>
+</head>
+<body class="gradient">
+  <section class="hero">
+    <h1 id="title" class="float">Hello World</h1>
+  </section>
+  <section class="controls">
+    <label>Background Color
+      <input type="color" id="bg-color" />
+    </label>
+    <label>Background Effect
+      <select id="bg-effect">
+        <option value="gradient" selected>Gradient</option>
+        <option value="solid">Solid</option>
+      </select>
+    </label>
+    <label>Text Color
+      <input type="color" id="text-color" value="#ffffff" />
+    </label>
+    <label>Text Animation
+      <select id="text-animation">
+        <option value="float" selected>Float</option>
+        <option value="spin">Spin</option>
+        <option value="pulse">Pulse</option>
+        <option value="none">None</option>
+      </select>
+    </label>
+  </section>
+  <script>
+    const body = document.body;
+    const title = document.getElementById('title');
+    const bgColor = document.getElementById('bg-color');
+    const textColor = document.getElementById('text-color');
+    const bgEffect = document.getElementById('bg-effect');
+    const textAnimation = document.getElementById('text-animation');
+
+    bgColor.addEventListener('input', () => {
+      if (bgEffect.value === 'solid') {
+        body.style.background = bgColor.value;
+      }
+    });
+
+    textColor.addEventListener('input', () => {
+      title.style.color = textColor.value;
+    });
+
+    bgEffect.addEventListener('change', () => {
+      if (bgEffect.value === 'gradient') {
+        body.classList.add('gradient');
+        body.style.background = '';
+      } else {
+        body.classList.remove('gradient');
+        body.style.background = bgColor.value;
+      }
+    });
+
+    textAnimation.addEventListener('change', () => {
+      title.classList.remove('float', 'spin', 'pulse');
+      if (textAnimation.value !== 'none') {
+        title.classList.add(textAnimation.value);
+      }
+    });
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- allow users to tweak background color, effect type, and text styling
- add selectable animations (float, spin, pulse) for the headline

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68acaa90f658832592ba1da46cd9561d